### PR TITLE
fix(seo): scope noindex to droidsize-web, canonicals, title template, remove /llms.txt from sitemap

### DIFF
--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site-config";
 
 export const metadata: Metadata = {
-	title: "About - Tarun Sharma",
+	title: "About",
 	description:
 		"Mobile app developer with 7+ years experience in iOS and Flutter. Currently building Chargespot and Domain Collective.",
+	alternates: {
+		canonical: `${SITE_URL}/about`,
+	},
 };
 
 export default function AboutLayout({

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site-config";
 
 export const metadata: Metadata = {
-	title: "Contact - Tarun Sharma",
+	title: "Contact",
 	description:
 		"Get in touch for iOS development, Flutter apps, or full-stack projects. Open to collaboration and contract work.",
+	alternates: {
+		canonical: `${SITE_URL}/contact`,
+	},
 };
 
 export default function ContactLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,10 @@ export function generateMetadata(): Metadata {
 	};
 
 	return {
-		title: "Tarun Sharma - Mobile App Developer | itstarun.fyi",
+		title: {
+			template: "%s | Tarun Sharma",
+			default: "Tarun Sharma - Mobile App Developer | itstarun.fyi",
+		},
 		description:
 			"Personal portfolio showcasing iOS and Flutter work, experience, and projects. Mobile app developer focused on stable releases and product quality.",
 		keywords: [
@@ -65,8 +68,8 @@ export function generateMetadata(): Metadata {
 			title: "Tarun",
 			description:
 				"Portfolio showcasing iOS and Flutter work, experience, and projects.",
-			creator: "@itsTarun",
-			site: "@itsTarun",
+			creator: "@itstarun1994",
+			site: "@itstarun1994",
 			images: [defaultSocialImage],
 		},
 		icons: {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site-config";
 
 export const metadata: Metadata = {
-	title: "Privacy Policy - Tarun Portfolio",
+	title: "Privacy Policy",
 	description: "Privacy policy for itstarun.fyi portfolio website",
+	alternates: {
+		canonical: `${SITE_URL}/privacy`,
+	},
 };
 
 export default function PrivacyPage() {

--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site-config";
 
 export const metadata: Metadata = {
-	title: "Projects - Tarun Sharma",
+	title: "Projects",
 	description:
 		"Flagship projects in iOS, Flutter, and full-stack development. Shipped products including Chargespot, OpenTribe, Domain Collective, and Repo Press.",
+	alternates: {
+		canonical: `${SITE_URL}/projects`,
+	},
 };
 
 export default function ProjectsLayout({

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -6,7 +6,7 @@ describe("sitemap", () => {
 		const entries = await sitemap();
 		const urls = entries.map((entry) => entry.url);
 
-		expect(urls).toContain("https://itstarun.fyi/llms.txt");
+		expect(urls).not.toContain("https://itstarun.fyi/llms.txt");
 		expect(urls).toContain("https://itstarun.fyi/privacy");
 		expect(urls).toContain("https://itstarun.fyi/projects/chargespot");
 		expect(urls).toContain("https://itstarun.fyi/projects/domain-collective");

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,7 +11,6 @@ type StaticRouteConfig = {
 const STATIC_ROUTES: StaticRouteConfig[] = [
 	{ path: "", changeFrequency: "monthly", priority: 1 },
 	{ path: "/about", changeFrequency: "monthly", priority: 0.8 },
-	{ path: "/llms.txt", changeFrequency: "monthly", priority: 0.4 },
 	{ path: "/projects", changeFrequency: "weekly", priority: 0.9 },
 	{ path: "/projects/chargespot", changeFrequency: "monthly", priority: 0.8 },
 	{

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,20 @@
 {
-	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"headers": [
-		{
-			"source": "/(.*)",
-			"headers": [
-				{
-					"key": "X-Robots-Tag",
-					"value": "noindex, nofollow"
-				}
-			]
-		}
-	]
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "droidsize-web.vercel.app"
+        }
+      ],
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    }
+  ]
 }

--- a/vercel.test.ts
+++ b/vercel.test.ts
@@ -2,26 +2,35 @@ import { describe, expect, it } from "vitest";
 import vercelConfig from "./vercel.json";
 
 describe("vercel.json headers configuration", () => {
-	it("should apply X-Robots-Tag header to all routes", () => {
-		const headers = vercelConfig.headers;
+  it("should apply X-Robots-Tag only to preview deployments", () => {
+    const allRoutesRule = vercelConfig.headers.find(
+      (rule) => rule.source === "/(.*)",
+    );
 
-		// Find the header rule that matches all routes
-		const allRoutesRule = headers.find((rule) => rule.source === "/(.*)");
+    expect(allRoutesRule).toBeDefined();
+    expect(allRoutesRule?.headers.some((h) => h.key === "X-Robots-Tag")).toBe(
+      true,
+    );
+  });
 
-		expect(allRoutesRule).toBeDefined();
-		expect(allRoutesRule?.headers.some((h) => h.key === "X-Robots-Tag")).toBe(
-			true,
-		);
-	});
+  it("should scope X-Robots-Tag to the preview host", () => {
+    const allRoutesRule = vercelConfig.headers.find(
+      (rule) => rule.source === "/(.*)",
+    );
 
-	it('should have X-Robots-Tag header value of "noindex, nofollow"', () => {
-		const headers = vercelConfig.headers;
+    expect(allRoutesRule?.has).toEqual([
+      { type: "host", value: "droidsize-web.vercel.app" },
+    ]);
+  });
 
-		const allRoutesRule = headers.find((rule) => rule.source === "/(.*)");
-		const xRobotsTag = allRoutesRule?.headers.find(
-			(h) => h.key === "X-Robots-Tag",
-		);
+  it('should have X-Robots-Tag value of "noindex, nofollow"', () => {
+    const allRoutesRule = vercelConfig.headers.find(
+      (rule) => rule.source === "/(.*)",
+    );
+    const xRobotsTag = allRoutesRule?.headers.find(
+      (h) => h.key === "X-Robots-Tag",
+    );
 
-		expect(xRobotsTag?.value).toBe("noindex, nofollow");
-	});
+    expect(xRobotsTag?.value).toBe("noindex, nofollow");
+  });
 });


### PR DESCRIPTION
SEO improvements for Google Search Console:

- Scope noindex to `droidsize-web.vercel.app` preview host only (production can be indexed)
- Add canonical URLs to /about, /contact, /projects, /privacy
- Set title template `%s | Tarun Sharma`
- Set twitter:creator to `@itstarun1994`
- Remove /llms.txt from sitemap and robots.txt

Verified on preview deployment: https://portfolio-site-luu4kvmh6-itstarun1994-6708s-projects.vercel.app