### PR TITLE
refactor(seo): server-render page content with CSS entrance animations

### DIFF
--- a/docs/2026-08-10-server-component-pages-design.md
+++ b/docs/2026-08-10-server-component-pages-design.md
@@ -23,8 +23,11 @@ Server components everywhere; entrance animation moves to CSS.
 - Stagger via inline `style={{ animationDelay: "…ms" }}`.
 - `backwards` fill means content is visible whenever the animation is not
   running — no blank state, no JS dependency.
-- The existing global `prefers-reduced-motion: reduce` block already zeroes
-  all animation durations; no extra guard needed.
+- The existing global `prefers-reduced-motion: reduce` block zeroes animation
+  durations but **not delays** — with `backwards` fill, a pending delay holds
+  content invisible. This change therefore adds `animation-delay: 0ms
+  !important` to that block so reduced-motion users see staggered content
+  immediately instead of it blinking in up to 240ms late.
 
 ### Per page
 
@@ -45,8 +48,21 @@ Server components everywhere; entrance animation moves to CSS.
 ### Out of scope
 
 - Site chrome keeps Framer Motion: header, footer, scroll-progress,
-  animated-counter, not-found. The `framer-motion` dependency stays.
+  not-found. The `framer-motion` dependency stays.
 - Project detail pages (`/projects/[slug]`) — already server-rendered.
+
+### Addenda (landed with this branch)
+
+- `animated-counter.tsx` was originally out of scope, but its own
+  `initial={{ opacity: 0 }}` Framer entrance SSR'd the hero stat tiles
+  invisible — the audit finding in miniature. Its motion wrappers were
+  removed; it stays a client island (framer's `useInView` drives the
+  count-up).
+- `scripts/internal-link-smoke.mjs` rider: the script spawned `npm run
+  start` and killed only the npm wrapper, orphaning `next-server`, whose
+  open stdio pipes kept the process alive until CI's 15-minute timeout —
+  every historical run of the workflow was cancelled this way. It now
+  spawns the `next` bin directly and escalates to SIGKILL after 5s.
 
 ## Acceptance
 

--- a/docs/2026-08-10-server-component-pages-design.md
+++ b/docs/2026-08-10-server-component-pages-design.md
@@ -1,0 +1,61 @@
+# Server-component pages with CSS entrance animations
+
+**Date:** 2026-08-10
+**Origin:** Google Search Console SEO audit, finding #14 — pages are fully
+client components; `/about` (and the others) render blank HTML until JS
+hydrates and the Framer Motion entrance runs. Real LCP/INP cost, and crawlers
+that don't execute JS see no content.
+
+## Goal
+
+Content for `/`, `/about`, `/projects`, and `/contact` renders in the initial
+HTML. Entrance animations are preserved in feel (fade + rise) but no longer
+gate visibility on hydration.
+
+## Approach (approved)
+
+Server components everywhere; entrance animation moves to CSS.
+
+### New CSS utility (`src/app/globals.css`)
+
+- One `rise` keyframe: `opacity 0 → 1`, `translateY(20px) → 0`.
+- `.animate-rise` class: `animation: rise 0.5s ease-out backwards`.
+- Stagger via inline `style={{ animationDelay: "…ms" }}`.
+- `backwards` fill means content is visible whenever the animation is not
+  running — no blank state, no JS dependency.
+- The existing global `prefers-reduced-motion: reduce` block already zeroes
+  all animation durations; no extra guard needed.
+
+### Per page
+
+| File | Change |
+|---|---|
+| `src/app/about/page.tsx` | Drop `"use client"` + framer. `animate` blocks → `animate-rise` divs; `whileInView` blocks → wrap in existing `ScrollReveal`. |
+| `src/app/projects/page.tsx` | Same; card stagger via inline `animationDelay` (index × 80ms). |
+| `src/app/page.tsx` + `src/components/home/*` | Page loses `"use client"` (trivial). Hero entrance → `animate-rise`; `AnimatedCounter` remains a client island inside it. Timeline/Projects/CTA `whileInView` → `ScrollReveal`. |
+| `src/app/contact/page.tsx` | Split: page becomes a server component (left column, layout, `animate-rise`); form (state, fetch, success panel) extracted to new client component `src/app/contact/contact-form.tsx`. |
+
+### Reused pieces
+
+- `src/components/animation/scroll-reveal.tsx` — existing SSR-safe client
+  wrapper: children are server-rendered and visible by default; it only hides
+  and reveals elements after JS confirms motion is OK and the element is
+  off-screen. This is the only in-view mechanism; no new one is written.
+
+### Out of scope
+
+- Site chrome keeps Framer Motion: header, footer, scroll-progress,
+  animated-counter, not-found. The `framer-motion` dependency stays.
+- Project detail pages (`/projects/[slug]`) — already server-rendered.
+
+## Acceptance
+
+1. `curl` of each built route (`next start`) contains the page `h1` text in
+   raw HTML: `/` ("Mobile apps that feel calm"), `/about` ("Building mobile
+   products"), `/projects` ("Flagship projects"), `/contact` ("Let's work
+   together").
+2. `pnpm build` — clean, still 17 static pages.
+3. `pnpm test` — all green.
+4. `pnpm biome:check` — clean (4 pre-existing `!important` warnings in
+   globals.css are expected).
+5. Contact form still submits (client island unchanged in behaviour).

--- a/scripts/internal-link-smoke.mjs
+++ b/scripts/internal-link-smoke.mjs
@@ -114,13 +114,21 @@ async function run() {
 	console.log(
 		`Starting Next.js server on port ${PORT} for internal link smoke checks...`,
 	);
-	const server = spawn("npm", ["run", "start", "--", "--port", String(PORT)], {
-		stdio: ["ignore", "pipe", "pipe"],
-		env: {
-			...process.env,
-			PORT: String(PORT),
+	// Spawn the next binary directly (no npm/sh wrapper tree): the child IS
+	// the server, so kill() below reaches it. Killing a wrapper instead left
+	// an orphaned next-server holding our stdio pipes open, which kept this
+	// process alive until CI's job timeout cancelled the run.
+	const server = spawn(
+		process.execPath,
+		["node_modules/next/dist/bin/next", "start", "--port", String(PORT)],
+		{
+			stdio: ["ignore", "pipe", "pipe"],
+			env: {
+				...process.env,
+				PORT: String(PORT),
+			},
 		},
-	});
+	);
 
 	server.stdout.on("data", (chunk) => process.stdout.write(chunk));
 	server.stderr.on("data", (chunk) => process.stderr.write(chunk));
@@ -175,6 +183,8 @@ async function run() {
 		);
 	} finally {
 		server.kill("SIGTERM");
+		// If the server ignores SIGTERM, don't let its pipes hold us open.
+		setTimeout(() => server.kill("SIGKILL"), 5000).unref();
 	}
 }
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,9 +1,7 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { Download, ExternalLink, GraduationCap, MapPin } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { ScrollReveal } from "@/components/animation/scroll-reveal";
 import { BreadcrumbSchema } from "@/components/seo/breadcrumb-schema";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -148,19 +146,9 @@ export default function AboutPage() {
 			<BreadcrumbSchema breadcrumbs={breadcrumbs} />
 			<div className="min-h-screen">
 				<div className="container max-w-6xl mx-auto px-4 py-16 md:py-20 lg:py-24 sm:px-6 lg:px-8">
-					<motion.div
-						initial={{ opacity: 0, y: 20 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ duration: 0.6 }}
-						className="mx-auto max-w-4xl"
-					>
+					<div className="mx-auto max-w-4xl">
 						<Breadcrumb items={toBreadcrumbItems(breadcrumbs)} />
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ delay: 0.2 }}
-							className="mb-12 grid gap-8 md:grid-cols-[1fr_300px] md:items-start"
-						>
+						<div className="animate-rise mb-12 grid gap-8 md:grid-cols-[1fr_300px] md:items-start">
 							<div>
 								<h1 className="section-title">
 									Building mobile products with clarity.
@@ -198,13 +186,11 @@ export default function AboutPage() {
 									className="w-full h-auto object-cover"
 								/>
 							</div>
-						</motion.div>
+						</div>
 
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ delay: 0.3 }}
-							className="mb-12 neo-panel p-8"
+						<div
+							className="animate-rise mb-12 neo-panel p-8"
+							style={{ animationDelay: "120ms" }}
 						>
 							<p className="mb-4 text-lg leading-relaxed">
 								I&apos;m a mobile developer focused on iOS and Flutter. Since
@@ -216,15 +202,9 @@ export default function AboutPage() {
 								partner closely with PM, QA, and UX to improve user experience,
 								keep releases stable, and maintain parity across platforms.
 							</p>
-						</motion.div>
+						</div>
 
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							viewport={{ once: true }}
-							transition={{ duration: 0.5 }}
-							className="mb-12"
-						>
+						<ScrollReveal className="mb-12">
 							<h2 className="mb-6 text-2xl font-semibold">
 								Skills & Expertise
 							</h2>
@@ -244,24 +224,15 @@ export default function AboutPage() {
 									</div>
 								))}
 							</div>
-						</motion.div>
+						</ScrollReveal>
 
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							viewport={{ once: true }}
-							transition={{ duration: 0.5 }}
-							className="mb-12"
-						>
+						<ScrollReveal className="mb-12">
 							<h2 className="mb-6 text-2xl font-semibold">Experience</h2>
 							<div className="space-y-6">
 								{experience.map((exp, idx) => (
-									<motion.div
+									<ScrollReveal
 										key={exp.id}
-										initial={{ opacity: 0, y: 12 }}
-										whileInView={{ opacity: 1, y: 0 }}
-										viewport={{ once: true }}
-										transition={{ duration: 0.4, delay: idx * 0.06 }}
+										delay={idx * 60}
 										className="neo-panel p-6"
 									>
 										<div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -289,18 +260,12 @@ export default function AboutPage() {
 												</Badge>
 											))}
 										</div>
-									</motion.div>
+									</ScrollReveal>
 								))}
 							</div>
-						</motion.div>
+						</ScrollReveal>
 
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							viewport={{ once: true }}
-							transition={{ duration: 0.5 }}
-							className="mb-12"
-						>
+						<ScrollReveal className="mb-12">
 							<h2 className="mb-6 text-2xl font-semibold">Education</h2>
 							<div className="neo-panel p-6">
 								<div className="mb-2 flex items-start gap-3">
@@ -323,15 +288,9 @@ export default function AboutPage() {
 									</div>
 								</div>
 							</div>
-						</motion.div>
+						</ScrollReveal>
 
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							viewport={{ once: true }}
-							transition={{ duration: 0.5 }}
-							className="neo-panel p-8 text-center"
-						>
+						<ScrollReveal className="neo-panel p-8 text-center">
 							<h2 className="mb-4 text-2xl font-semibold">
 								Let&apos;s work together
 							</h2>
@@ -341,8 +300,8 @@ export default function AboutPage() {
 							<Button asChild>
 								<Link href="/contact">Get in touch</Link>
 							</Button>
-						</motion.div>
-					</motion.div>
+						</ScrollReveal>
+					</div>
 				</div>
 			</div>
 		</>

--- a/src/app/contact/contact-form.tsx
+++ b/src/app/contact/contact-form.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { CONTACT_EMAIL } from "@/lib/site-config";
+
+type FormState = "idle" | "submitting" | "success" | "error";
+
+const inputClass =
+	"mt-2 w-full border-2 border-border bg-background px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50";
+
+export function ContactForm() {
+	const [formState, setFormState] = useState<FormState>("idle");
+	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+	const [values, setValues] = useState({
+		name: "",
+		email: "",
+		subject: "",
+		message: "",
+	});
+
+	const handleChange = (
+		e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+	) => {
+		setValues((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+		if (errorMsg) setErrorMsg(null);
+	};
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		setFormState("submitting");
+		setErrorMsg(null);
+
+		try {
+			const res = await fetch("/api/contact", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(values),
+			});
+
+			const data = await res.json();
+
+			if (!res.ok) {
+				setErrorMsg(data.error ?? "Something went wrong. Please try again.");
+				setFormState("error");
+				return;
+			}
+
+			setFormState("success");
+		} catch {
+			setErrorMsg("Network error. Please try again or email me directly.");
+			setFormState("error");
+		}
+	};
+
+	const handleReset = () => {
+		setFormState("idle");
+		setErrorMsg(null);
+		setValues({ name: "", email: "", subject: "", message: "" });
+	};
+
+	const isSubmitting = formState === "submitting";
+
+	if (formState === "success") {
+		return (
+			// biome-ignore lint/a11y/useSemanticElements: <output> permits only phrasing content; this panel holds a heading and button, so role="status" on the container is the correct live-region choice
+			<div role="status" aria-live="polite" className="neo-panel p-8 md:p-10">
+				<p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+					Sent
+				</p>
+				<h2 className="mt-3 text-2xl font-semibold">Message received.</h2>
+				<p className="mt-3 text-sm text-muted-foreground leading-relaxed">
+					I&apos;ll get back to you within one business day. If it&apos;s
+					urgent, email me directly at{" "}
+					<a
+						href={`mailto:${CONTACT_EMAIL}`}
+						className="text-foreground underline underline-offset-4"
+					>
+						{CONTACT_EMAIL}
+					</a>
+					.
+				</p>
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={handleReset}
+					className="mt-6"
+				>
+					Send another message
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<form onSubmit={handleSubmit} noValidate className="space-y-6">
+			<div className="grid gap-6 sm:grid-cols-2">
+				<div>
+					<label
+						htmlFor="name"
+						className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
+					>
+						Name{" "}
+						<span aria-hidden="true" className="text-destructive">
+							*
+						</span>
+					</label>
+					<input
+						id="name"
+						name="name"
+						type="text"
+						required
+						autoComplete="name"
+						value={values.name}
+						onChange={handleChange}
+						placeholder="Your name"
+						className={inputClass}
+						disabled={isSubmitting}
+					/>
+				</div>
+				<div>
+					<label
+						htmlFor="email"
+						className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
+					>
+						Email{" "}
+						<span aria-hidden="true" className="text-destructive">
+							*
+						</span>
+					</label>
+					<input
+						id="email"
+						name="email"
+						type="email"
+						required
+						autoComplete="email"
+						value={values.email}
+						onChange={handleChange}
+						placeholder="you@company.com"
+						className={inputClass}
+						disabled={isSubmitting}
+					/>
+				</div>
+			</div>
+
+			<div>
+				<label
+					htmlFor="subject"
+					className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
+				>
+					Subject{" "}
+					<span className="font-normal normal-case tracking-normal text-muted-foreground">
+						(optional)
+					</span>
+				</label>
+				<input
+					id="subject"
+					name="subject"
+					type="text"
+					autoComplete="off"
+					value={values.subject}
+					onChange={handleChange}
+					placeholder="iOS freelance — 3-month contract"
+					className={inputClass}
+					disabled={isSubmitting}
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="message"
+					className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
+				>
+					Message{" "}
+					<span aria-hidden="true" className="text-destructive">
+						*
+					</span>
+				</label>
+				<textarea
+					id="message"
+					name="message"
+					required
+					rows={6}
+					value={values.message}
+					onChange={handleChange}
+					placeholder="What are you building? Timeline, stack, what you need from me."
+					className={`${inputClass} resize-y rounded-sm`}
+					disabled={isSubmitting}
+				/>
+			</div>
+
+			{errorMsg && (
+				<div
+					role="alert"
+					className="border-2 border-destructive bg-destructive/5 px-4 py-3 text-sm text-destructive"
+				>
+					{errorMsg}
+				</div>
+			)}
+
+			<Button
+				type="submit"
+				size="lg"
+				disabled={isSubmitting}
+				className="w-full sm:w-auto"
+			>
+				{isSubmitting ? "Sending…" : "Send Message"}
+			</Button>
+		</form>
+	);
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,16 +1,6 @@
-"use client";
-
-import { motion, useReducedMotion } from "framer-motion";
 import { Download, ExternalLink } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import {
-	CONTACT_EMAIL,
-	RESUME_DOWNLOAD_LINK_PROPS,
-	RESUME_URL,
-} from "@/lib/site-config";
-
-type FormState = "idle" | "submitting" | "success" | "error";
+import { RESUME_DOWNLOAD_LINK_PROPS, RESUME_URL } from "@/lib/site-config";
+import { ContactForm } from "./contact-form";
 
 const helpList = [
 	"iOS app development",
@@ -20,81 +10,16 @@ const helpList = [
 	"Mobile tech advisory",
 ];
 
-const inputClass =
-	"mt-2 w-full border-2 border-border bg-background px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50";
-
 const resumeLinkClass =
 	"inline-flex items-center gap-2 text-sm text-foreground underline underline-offset-4 transition-colors hover:text-muted-foreground";
 
 export default function ContactPage() {
-	const reduceMotion = useReducedMotion();
-	const [formState, setFormState] = useState<FormState>("idle");
-	const [errorMsg, setErrorMsg] = useState<string | null>(null);
-
-	// Entrance that respects prefers-reduced-motion. Framer animations are
-	// JS-driven and bypass the CSS reduced-motion floor in globals.css, so
-	// gate them here. `animate` always targets the visible state, so content
-	// can never get stuck invisible once hydrated.
-	const entrance = (delay = 0) => ({
-		initial: reduceMotion ? false : ({ opacity: 0, y: 20 } as const),
-		animate: { opacity: 1, y: 0 },
-		transition: reduceMotion ? { duration: 0 } : { duration: 0.5, delay },
-	});
-	const [values, setValues] = useState({
-		name: "",
-		email: "",
-		subject: "",
-		message: "",
-	});
-
-	const handleChange = (
-		e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-	) => {
-		setValues((prev) => ({ ...prev, [e.target.name]: e.target.value }));
-		if (errorMsg) setErrorMsg(null);
-	};
-
-	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		setFormState("submitting");
-		setErrorMsg(null);
-
-		try {
-			const res = await fetch("/api/contact", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(values),
-			});
-
-			const data = await res.json();
-
-			if (!res.ok) {
-				setErrorMsg(data.error ?? "Something went wrong. Please try again.");
-				setFormState("error");
-				return;
-			}
-
-			setFormState("success");
-		} catch {
-			setErrorMsg("Network error. Please try again or email me directly.");
-			setFormState("error");
-		}
-	};
-
-	const handleReset = () => {
-		setFormState("idle");
-		setErrorMsg(null);
-		setValues({ name: "", email: "", subject: "", message: "" });
-	};
-
-	const isSubmitting = formState === "submitting";
-
 	return (
 		<div className="min-h-screen">
 			<div className="container max-w-6xl mx-auto px-4 py-16 md:py-20 lg:py-24 sm:px-6 lg:px-8">
 				<div className="grid gap-16 lg:grid-cols-5 lg:gap-24">
 					{/* Left: context */}
-					<motion.div {...entrance()} className="lg:col-span-2">
+					<div className="animate-rise lg:col-span-2">
 						<h1 className="section-title">Let&apos;s work together.</h1>
 						<p className="section-subtitle mt-4">
 							Open to iOS and Flutter contract work. No agencies or generic
@@ -150,160 +75,15 @@ export default function ContactPage() {
 						<p className="mt-10 text-xs text-muted-foreground">
 							Typically responds within one business day.
 						</p>
-					</motion.div>
+					</div>
 
 					{/* Right: form */}
-					<motion.div {...entrance(0.15)} className="lg:col-span-3">
-						{formState === "success" ? (
-							// biome-ignore lint/a11y/useSemanticElements: <output> permits only phrasing content; this panel holds a heading and button, so role="status" on the container is the correct live-region choice
-							<div
-								role="status"
-								aria-live="polite"
-								className="neo-panel p-8 md:p-10"
-							>
-								<p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">
-									Sent
-								</p>
-								<h2 className="mt-3 text-2xl font-semibold">
-									Message received.
-								</h2>
-								<p className="mt-3 text-sm text-muted-foreground leading-relaxed">
-									I&apos;ll get back to you within one business day. If
-									it&apos;s urgent, email me directly at{" "}
-									<a
-										href={`mailto:${CONTACT_EMAIL}`}
-										className="text-foreground underline underline-offset-4"
-									>
-										{CONTACT_EMAIL}
-									</a>
-									.
-								</p>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={handleReset}
-									className="mt-6"
-								>
-									Send another message
-								</Button>
-							</div>
-						) : (
-							<form onSubmit={handleSubmit} noValidate className="space-y-6">
-								<div className="grid gap-6 sm:grid-cols-2">
-									<div>
-										<label
-											htmlFor="name"
-											className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
-										>
-											Name{" "}
-											<span aria-hidden="true" className="text-destructive">
-												*
-											</span>
-										</label>
-										<input
-											id="name"
-											name="name"
-											type="text"
-											required
-											autoComplete="name"
-											value={values.name}
-											onChange={handleChange}
-											placeholder="Your name"
-											className={inputClass}
-											disabled={isSubmitting}
-										/>
-									</div>
-									<div>
-										<label
-											htmlFor="email"
-											className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
-										>
-											Email{" "}
-											<span aria-hidden="true" className="text-destructive">
-												*
-											</span>
-										</label>
-										<input
-											id="email"
-											name="email"
-											type="email"
-											required
-											autoComplete="email"
-											value={values.email}
-											onChange={handleChange}
-											placeholder="you@company.com"
-											className={inputClass}
-											disabled={isSubmitting}
-										/>
-									</div>
-								</div>
-
-								<div>
-									<label
-										htmlFor="subject"
-										className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
-									>
-										Subject{" "}
-										<span className="font-normal normal-case tracking-normal text-muted-foreground">
-											(optional)
-										</span>
-									</label>
-									<input
-										id="subject"
-										name="subject"
-										type="text"
-										autoComplete="off"
-										value={values.subject}
-										onChange={handleChange}
-										placeholder="iOS freelance — 3-month contract"
-										className={inputClass}
-										disabled={isSubmitting}
-									/>
-								</div>
-
-								<div>
-									<label
-										htmlFor="message"
-										className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground"
-									>
-										Message{" "}
-										<span aria-hidden="true" className="text-destructive">
-											*
-										</span>
-									</label>
-									<textarea
-										id="message"
-										name="message"
-										required
-										rows={6}
-										value={values.message}
-										onChange={handleChange}
-										placeholder="What are you building? Timeline, stack, what you need from me."
-										className={`${inputClass} resize-y rounded-sm`}
-										disabled={isSubmitting}
-									/>
-								</div>
-
-								{errorMsg && (
-									<div
-										role="alert"
-										className="border-2 border-destructive bg-destructive/5 px-4 py-3 text-sm text-destructive"
-									>
-										{errorMsg}
-									</div>
-								)}
-
-								<Button
-									type="submit"
-									size="lg"
-									disabled={isSubmitting}
-									className="w-full sm:w-auto"
-								>
-									{isSubmitting ? "Sending…" : "Send Message"}
-								</Button>
-							</form>
-						)}
-					</motion.div>
+					<div
+						className="animate-rise lg:col-span-3"
+						style={{ animationDelay: "150ms" }}
+					>
+						<ContactForm />
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -283,6 +283,7 @@
 	*::before,
 	*::after {
 		animation-duration: 0.01ms !important;
+		animation-delay: 0ms !important;
 		animation-iteration-count: 1 !important;
 		transition-duration: 0.01ms !important;
 		scroll-behavior: auto !important;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -307,3 +307,17 @@
 		transform: translateY(0);
 	}
 }
+
+@keyframes rise {
+	from {
+		opacity: 0;
+		transform: translateY(20px);
+	}
+}
+
+/* Entrance for server-rendered content: runs without JS, and the global
+   reduced-motion block above collapses it to ~0ms for those users.
+   `backwards` keeps pre-delay frames at the `from` state during staggers. */
+.animate-rise {
+	animation: rise 0.5s ease-out backwards;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { CtaSection } from "@/components/home/cta-section";
 import { HeroSection } from "@/components/home/hero-section";
 import { ProjectsSection } from "@/components/home/projects-section";

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -128,79 +128,77 @@ export default function ProjectsPage() {
 	return (
 		<div className="min-h-screen">
 			<div className="container max-w-6xl mx-auto px-4 py-16 md:py-20 lg:py-24 sm:px-6 lg:px-8">
-				<div>
-					<div className="animate-rise mb-12">
-						<h1 className="section-title">Flagship projects</h1>
-						<p className="section-subtitle mt-4 max-w-2xl">
-							Deep dives into the products I&apos;ve shipped across web and
-							mobile.
-						</p>
-					</div>
+				<div className="animate-rise mb-12">
+					<h1 className="section-title">Flagship projects</h1>
+					<p className="section-subtitle mt-4 max-w-2xl">
+						Deep dives into the products I&apos;ve shipped across web and
+						mobile.
+					</p>
+				</div>
 
-					<div className="grid gap-6 md:grid-cols-2">
-						{flagshipProjects.map((project, idx) => (
-							<div
-								key={project.id}
-								className="animate-rise neo-panel flex flex-col overflow-hidden transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_hsl(var(--border))]"
-								style={{ animationDelay: `${idx * 80}ms` }}
-							>
-								<div className="relative h-40 w-full flex-shrink-0 overflow-hidden border-b-2 border-border">
-									<Image
-										src={project.imageUrl}
-										alt={`${project.title} screenshot`}
-										fill
-										sizes="(min-width: 768px) 50vw, 100vw"
-										className="object-cover"
-									/>
+				<div className="grid gap-6 md:grid-cols-2">
+					{flagshipProjects.map((project, idx) => (
+						<div
+							key={project.id}
+							className="animate-rise neo-panel flex flex-col overflow-hidden transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_hsl(var(--border))]"
+							style={{ animationDelay: `${idx * 80}ms` }}
+						>
+							<div className="relative h-40 w-full flex-shrink-0 overflow-hidden border-b-2 border-border">
+								<Image
+									src={project.imageUrl}
+									alt={`${project.title} screenshot`}
+									fill
+									sizes="(min-width: 768px) 50vw, 100vw"
+									className="object-cover"
+								/>
+							</div>
+
+							<div className="flex flex-col flex-1 p-6">
+								<div className="mb-4 flex items-start justify-between gap-4">
+									<h2 className="text-2xl font-semibold">{project.title}</h2>
+									<div className="flex gap-2">
+										<Button asChild size="sm">
+											<Link href={`/projects/${project.id}`}>View</Link>
+										</Button>
+										{project.liveUrl && (
+											<Button asChild size="sm" variant="outline">
+												<a
+													href={project.liveUrl}
+													target="_blank"
+													rel="noopener noreferrer"
+													aria-label={`${project.title} live site`}
+												>
+													<ExternalLink className="h-3.5 w-3.5" />
+												</a>
+											</Button>
+										)}
+									</div>
 								</div>
 
-								<div className="flex flex-col flex-1 p-6">
-									<div className="mb-4 flex items-start justify-between gap-4">
-										<h2 className="text-2xl font-semibold">{project.title}</h2>
-										<div className="flex gap-2">
-											<Button asChild size="sm">
-												<Link href={`/projects/${project.id}`}>View</Link>
-											</Button>
-											{project.liveUrl && (
-												<Button asChild size="sm" variant="outline">
-													<a
-														href={project.liveUrl}
-														target="_blank"
-														rel="noopener noreferrer"
-														aria-label={`${project.title} live site`}
-													>
-														<ExternalLink className="h-3.5 w-3.5" />
-													</a>
-												</Button>
-											)}
-										</div>
-									</div>
+								<p className="mb-5 text-sm text-muted-foreground leading-relaxed flex-1">
+									{project.description}
+								</p>
 
-									<p className="mb-5 text-sm text-muted-foreground leading-relaxed flex-1">
-										{project.description}
+								<div className="border-t-2 border-border pt-4">
+									<p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+										Stack
 									</p>
-
-									<div className="border-t-2 border-border pt-4">
-										<p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-											Stack
-										</p>
-										<div className="flex flex-wrap gap-1.5">
-											{project.technologies.slice(0, 6).map((tech) => (
-												<Badge key={tech} variant="secondary">
-													{tech}
-												</Badge>
-											))}
-											{project.technologies.length > 6 && (
-												<Badge variant="outline">
-													+{project.technologies.length - 6}
-												</Badge>
-											)}
-										</div>
+									<div className="flex flex-wrap gap-1.5">
+										{project.technologies.slice(0, 6).map((tech) => (
+											<Badge key={tech} variant="secondary">
+												{tech}
+											</Badge>
+										))}
+										{project.technologies.length > 6 && (
+											<Badge variant="outline">
+												+{project.technologies.length - 6}
+											</Badge>
+										)}
 									</div>
 								</div>
 							</div>
-						))}
-					</div>
+						</div>
+					))}
 				</div>
 			</div>
 		</div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ExternalLink } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -127,53 +124,25 @@ const flagshipProjects = [
 	},
 ];
 
-const containerVariants = {
-	animate: {
-		transition: {
-			staggerChildren: 0.08,
-		},
-	},
-};
-
-const fadeInUp = {
-	initial: { opacity: 0, y: 20 },
-	animate: { opacity: 1, y: 0 },
-	transition: { duration: 0.5 },
-};
-
 export default function ProjectsPage() {
 	return (
 		<div className="min-h-screen">
 			<div className="container max-w-6xl mx-auto px-4 py-16 md:py-20 lg:py-24 sm:px-6 lg:px-8">
-				<motion.div
-					initial={{ opacity: 0, y: 20 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.6 }}
-				>
-					<motion.div
-						initial={{ opacity: 0, y: 20 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ delay: 0.2 }}
-						className="mb-12"
-					>
+				<div>
+					<div className="animate-rise mb-12">
 						<h1 className="section-title">Flagship projects</h1>
 						<p className="section-subtitle mt-4 max-w-2xl">
 							Deep dives into the products I&apos;ve shipped across web and
 							mobile.
 						</p>
-					</motion.div>
+					</div>
 
-					<motion.div
-						variants={containerVariants}
-						initial="initial"
-						animate="animate"
-						className="grid gap-6 md:grid-cols-2"
-					>
-						{flagshipProjects.map((project) => (
-							<motion.div
+					<div className="grid gap-6 md:grid-cols-2">
+						{flagshipProjects.map((project, idx) => (
+							<div
 								key={project.id}
-								variants={fadeInUp}
-								className="neo-panel flex flex-col overflow-hidden transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_hsl(var(--border))]"
+								className="animate-rise neo-panel flex flex-col overflow-hidden transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_hsl(var(--border))]"
+								style={{ animationDelay: `${idx * 80}ms` }}
 							>
 								<div className="relative h-40 w-full flex-shrink-0 overflow-hidden border-b-2 border-border">
 									<Image
@@ -229,10 +198,10 @@ export default function ProjectsPage() {
 										</div>
 									</div>
 								</div>
-							</motion.div>
+							</div>
 						))}
-					</motion.div>
-				</motion.div>
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/home/cta-section.tsx
+++ b/src/components/home/cta-section.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ArrowRight, Github, Linkedin, Mail, Twitter } from "lucide-react";
 import Link from "next/link";
 import { ScrollReveal } from "@/components/animation/scroll-reveal";
@@ -35,13 +32,8 @@ export function CtaSection() {
 		<section className="py-16 md:py-20 lg:py-24">
 			<div className="container max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 				<ScrollReveal>
-					<motion.div className="mx-auto max-w-4xl text-center neo-panel neo-panel-primary p-8 md:p-12">
-						<motion.div
-							initial={{ opacity: 0, scale: 0.9 }}
-							whileInView={{ opacity: 1, scale: 1 }}
-							transition={{ duration: 0.5 }}
-							className="mb-8"
-						>
+					<div className="mx-auto max-w-4xl text-center neo-panel neo-panel-primary p-8 md:p-12">
+						<div className="mb-8">
 							<h2 className="mb-4 text-3xl font-semibold sm:text-4xl text-balance text-primary-foreground">
 								Open to ambitious mobile product work with clear impact.
 							</h2>
@@ -49,14 +41,9 @@ export function CtaSection() {
 								I help teams ship thoughtful iOS and Flutter apps with confident
 								UX, clean engineering, and stable release quality.
 							</p>
-						</motion.div>
+						</div>
 
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							transition={{ delay: 0.2, duration: 0.5 }}
-							className="flex flex-col items-center gap-4 mb-10 sm:flex-row sm:justify-center"
-						>
+						<div className="flex flex-col items-center gap-4 mb-10 sm:flex-row sm:justify-center">
 							<Button
 								asChild
 								size="lg"
@@ -77,31 +64,23 @@ export function CtaSection() {
 							>
 								<Link href="/projects">View Selected Work</Link>
 							</Button>
-						</motion.div>
+						</div>
 
-						<motion.div
-							initial={{ opacity: 0 }}
-							whileInView={{ opacity: 1 }}
-							transition={{ delay: 0.4, duration: 0.5 }}
-							className="flex flex-wrap justify-center gap-4"
-						>
-							{socialLinks.map((social, index) => (
-								<motion.a
+						<div className="flex flex-wrap justify-center gap-4">
+							{socialLinks.map((social) => (
+								<a
 									key={social.label}
 									href={social.href}
 									target="_blank"
 									rel="noopener noreferrer"
 									aria-label={social.label}
-									initial={{ opacity: 0, y: 20 }}
-									whileInView={{ opacity: 1, y: 0 }}
-									transition={{ delay: 0.5 + index * 0.1 }}
 									className="text-xs font-semibold uppercase tracking-[0.2em] text-primary-foreground underline-offset-4 hover:underline"
 								>
 									{social.label}
-								</motion.a>
+								</a>
 							))}
-						</motion.div>
-					</motion.div>
+						</div>
+					</div>
 				</ScrollReveal>
 			</div>
 		</section>

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ArrowRight, Github, Linkedin, Mail, Twitter } from "lucide-react";
 import Link from "next/link";
 import { AnimatedCounter } from "@/components/ui/animated-counter";
@@ -42,12 +39,7 @@ export function HeroSection() {
 		<section className="relative border-b-2 border-border bg-background">
 			<div className="container mx-auto px-4 py-20 sm:px-6 lg:px-8">
 				<div className="grid gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
-					<motion.div
-						initial={{ opacity: 0, y: 16 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ duration: 0.6 }}
-						className="space-y-8"
-					>
+					<div className="animate-rise space-y-8">
 						<div className="flex flex-wrap items-center gap-3">
 							<span className="eyebrow">Mobile App Developer</span>
 							<span className="neo-chip">iOS</span>
@@ -95,13 +87,11 @@ export function HeroSection() {
 								</a>
 							))}
 						</div>
-					</motion.div>
+					</div>
 
-					<motion.div
-						initial={{ opacity: 0, y: 16 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ duration: 0.6, delay: 0.1 }}
-						className="space-y-6"
+					<div
+						className="animate-rise space-y-6"
+						style={{ animationDelay: "100ms" }}
 					>
 						<div className="neo-panel p-6">
 							<div className="mb-6 flex items-center justify-between">
@@ -124,7 +114,7 @@ export function HeroSection() {
 								</div>
 							</div>
 						</div>
-					</motion.div>
+					</div>
 				</div>
 			</div>
 		</section>

--- a/src/components/home/projects-section.tsx
+++ b/src/components/home/projects-section.tsx
@@ -1,8 +1,6 @@
-"use client";
-
-import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
+import { ScrollReveal } from "@/components/animation/scroll-reveal";
 import { Button } from "@/components/ui/button";
 import { PROJECTS } from "@/config/projects";
 import { type ProjectSlug, toProjectRoute } from "@/types";
@@ -23,13 +21,7 @@ function ProjectCard({
 	slug,
 }: ProjectCardProps) {
 	return (
-		<motion.div
-			initial={{ opacity: 0, y: 16 }}
-			whileInView={{ opacity: 1, y: 0 }}
-			viewport={{ once: true }}
-			transition={{ duration: 0.4, delay: index * 0.08 }}
-			className="h-full"
-		>
+		<ScrollReveal delay={index * 80} className="h-full">
 			<Link
 				href={toProjectRoute(slug)}
 				className="neo-panel flex h-full flex-col justify-between p-0 transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_hsl(var(--border))] overflow-hidden"
@@ -55,7 +47,7 @@ function ProjectCard({
 					View project →
 				</span>
 			</Link>
-		</motion.div>
+		</ScrollReveal>
 	);
 }
 
@@ -65,19 +57,13 @@ export function ProjectsSection() {
 	return (
 		<section className="border-b-2 border-border py-16 md:py-20 lg:py-24">
 			<div className="container max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-				<motion.div
-					initial={{ opacity: 0, y: 20 }}
-					whileInView={{ opacity: 1, y: 0 }}
-					viewport={{ once: true }}
-					transition={{ duration: 0.5 }}
-					className="mb-12"
-				>
+				<ScrollReveal className="mb-12">
 					<h2 className="section-title text-balance">Builds with range.</h2>
 					<p className="section-subtitle mt-4 max-w-2xl">
 						Shipped products and tools across mobile and web — built, iterated,
 						and used in the real world.
 					</p>
-				</motion.div>
+				</ScrollReveal>
 
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 lg:gap-10">
 					{projects.map((project, idx) => (
@@ -93,17 +79,11 @@ export function ProjectsSection() {
 				</div>
 
 				{projects.length > 3 && (
-					<motion.div
-						initial={{ opacity: 0, y: 12 }}
-						whileInView={{ opacity: 1, y: 0 }}
-						viewport={{ once: true }}
-						transition={{ duration: 0.4, delay: 0.3 }}
-						className="mt-12"
-					>
+					<ScrollReveal delay={300} className="mt-12">
 						<Button asChild variant="outline" size="lg">
 							<Link href="/projects">View all projects</Link>
 						</Button>
-					</motion.div>
+					</ScrollReveal>
 				)}
 			</div>
 		</section>

--- a/src/components/home/timeline-section.tsx
+++ b/src/components/home/timeline-section.tsx
@@ -1,8 +1,6 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { Calendar } from "lucide-react";
 import Link from "next/link";
+import { ScrollReveal } from "@/components/animation/scroll-reveal";
 
 const experiences = [
 	{
@@ -65,28 +63,19 @@ export function TimelineSection() {
 	return (
 		<section className="border-b-2 border-border py-16 md:py-20 lg:py-24">
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
-				<motion.div
-					initial={{ opacity: 0, y: 20 }}
-					whileInView={{ opacity: 1, y: 0 }}
-					viewport={{ once: true }}
-					transition={{ duration: 0.5 }}
-					className="mb-12"
-				>
+				<ScrollReveal className="mb-12">
 					<h2 className="section-title text-balance">Experience that ships.</h2>
 					<p className="section-subtitle mt-4 max-w-2xl">
 						A focused timeline of web and mobile products delivered with
 						reliable engineering and clear outcomes.
 					</p>
-				</motion.div>
+				</ScrollReveal>
 
 				<div className="space-y-6">
 					{experiences.map((exp, idx) => (
-						<motion.div
+						<ScrollReveal
 							key={`${exp.company}-${exp.period}`}
-							initial={{ opacity: 0, y: 16 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							viewport={{ once: true }}
-							transition={{ duration: 0.4, delay: idx * 0.08 }}
+							delay={idx * 80}
 							className="neo-panel p-6"
 						>
 							<div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -119,24 +108,18 @@ export function TimelineSection() {
 									</span>
 								))}
 							</div>
-						</motion.div>
+						</ScrollReveal>
 					))}
 				</div>
 
-				<motion.div
-					initial={{ opacity: 0, y: 12 }}
-					whileInView={{ opacity: 1, y: 0 }}
-					viewport={{ once: true }}
-					transition={{ duration: 0.4, delay: 0.3 }}
-					className="mt-8"
-				>
+				<ScrollReveal delay={300} className="mt-8">
 					<Link
 						href="/about"
 						className="inline-flex items-center border-2 border-border bg-background px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground transition-all hover:text-foreground hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_hsl(var(--border))]"
 					>
 						Full timeline →
 					</Link>
-				</motion.div>
+				</ScrollReveal>
 			</div>
 		</section>
 	);

--- a/src/components/ui/animated-counter.tsx
+++ b/src/components/ui/animated-counter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView, useReducedMotion } from "framer-motion";
+import { useInView, useReducedMotion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 
 interface StatItem {
@@ -66,18 +66,10 @@ function Counter({
 
 export function AnimatedCounter({ items }: AnimatedCounterProps) {
 	return (
-		<motion.div
-			initial={{ opacity: 0, y: 20 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={{ duration: 0.6, delay: 0.4 }}
-			className="grid grid-cols-2 gap-4"
-		>
-			{items.map((item, index) => (
-				<motion.div
+		<div className="grid grid-cols-2 gap-4">
+			{items.map((item) => (
+				<div
 					key={item.id}
-					initial={{ opacity: 0, y: 20 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.5, delay: 0.5 + index * 0.1 }}
 					className="border-2 border-border bg-background px-3 py-3"
 				>
 					<div className="flex items-center justify-between gap-2">
@@ -94,8 +86,8 @@ export function AnimatedCounter({ items }: AnimatedCounterProps) {
 					<div className="mt-2 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
 						{item.label}
 					</div>
-				</motion.div>
+				</div>
 			))}
-		</motion.div>
+		</div>
 	);
 }


### PR DESCRIPTION
Closes audit finding #14 (the last engineering item from the Search Console review): `/`, `/about`, `/projects`, and `/contact` were fully client components, so they rendered **blank HTML until JS hydrated** and the Framer Motion entrance ran — a real LCP/INP cost, and no content for non-JS crawlers.

Spec: `docs/2026-08-10-server-component-pages-design.md`

## What changed

- **New `.animate-rise` CSS utility** (`globals.css`): fade + 20px rise keyframe, `backwards` fill. Runs without JS. Content is in the initial HTML and can never be stuck hidden.
- **`/about`, `/projects`** — now server components. Above-fold entrances use `animate-rise` (stagger via inline `animationDelay`); below-fold reveals reuse the existing SSR-safe `ScrollReveal` island.
- **Home** — `page.tsx` and all four sections (hero, timeline, projects, CTA) are server components. CTA's nested Framer stagger flattened into its existing single `ScrollReveal` (deliberate simplification).
- **`/contact`** — split into a server page + new `contact-form.tsx` client island (form logic moved verbatim; the form markup itself still SSRs).
- **`AnimatedCounter`** — dropped its internal `opacity: 0` Framer entrance (it SSR'd the hero stat tiles invisible — same bug at small scale). The island now only does the count-up.

Site chrome (header, footer, scroll-progress, not-found) intentionally keeps Framer Motion; the dependency stays.

## Post-open additions (review findings)

- **`fix(ci)` — `scripts/internal-link-smoke.mjs`**: every historical run of the re-enabled Internal Link Smoke workflow was cancelled at the 15-min timeout because the script spawned `npm run start` and killed only the npm wrapper — the orphaned `next-server` held stdio pipes open so the process never exited (the check itself passed in <1s). Now spawns the `next` bin directly (child = server) with a 5s SIGKILL backstop. Verified locally: passes 12 routes and exits in 3.7s.
- **`fix(a11y)` — reduced-motion delay hole** (found by adversarial spec review): the global `prefers-reduced-motion` block zeroed `animation-duration` but not `animation-delay`, so `backwards`-fill staggers held content invisible up to 240ms for reduced-motion users. Added `animation-delay: 0ms !important` (biome's accepted `!important` warning count in that block goes 4 → 5). Also removed a dead wrapper `<div>` left behind in `projects/page.tsx`.

## Verification

- `pnpm build` clean — 17 static pages; first-load JS for the four routes dropped (e.g. `/about` 111 kB, previously carried framer in the page bundle)
- `pnpm test` 13/13 · `pnpm biome:check` clean (5 accepted `!important` warnings in globals.css, was 4 — see above)
- `next start` + curl: all four routes return 200 with their `h1` text **in raw HTML**; contact form inputs present in SSR output; `/about/opengraph-image` 200 with 39,601 bytes
- Browser check: content visible from first paint on all four routes; entrance plays once and settles; hero counters land at final values; contact form fields hydrate and are interactive
- Two-axis review (standards + spec sub-agents) run against `main`; all real findings fixed above, deliberate simplifications recorded in the spec's Addenda